### PR TITLE
Renovate and releaser improvements

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,9 +11,12 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": "^build\\.json$",
+      "fileMatch": ["^Dockerfile$", "^build.json$"],
+      "matchStringsStrategy": "any",
       "matchStrings": [
-        "\"teslamate_version\": \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+        "\"teslamate_version\": \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+        "FROM=teslamate/(grafana|teslamate):(?<currentValue>.*?)\\s+",
+        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?teslamate/teslamate:(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "teslamate-org/teslamate"

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -39,6 +39,15 @@ jobs:
           git tag -a v${{ steps.semver.outputs.semver }} -m 'Release automation'
           git push --tags
         working-directory: ${{ github.workspace }}/teslamate
+      - name: Get TeslaMate release notes
+        run: |
+          gh pr list --repo lildude/ha-addon-teslamate --state=merged --search="Update TeslaMate" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
+          if [ -s changelog.tmp ]; then
+            echo "## TeslaMate Release Notes" > CHANGELOG.txt
+            cat changelog.tmp >> CHANGELOG.txt
+            echo "---" >> CHANGELOG.txt
+          fi
+          rm -f CHANGELOG.txt
       - name: Create release
         uses: softprops/action-gh-release@v2.0.5
         with:
@@ -56,7 +65,7 @@ jobs:
 
       - name: Update addon repo
         run: |
-          cp -vf ${{ github.workspace }}/teslamate/*.png ${{ github.workspace }}/repo/teslamate 
+          cp -vf ${{ github.workspace }}/teslamate/*.png ${{ github.workspace }}/repo/teslamate
           cp -vf ${{ github.workspace }}/teslamate/*.md ${{ github.workspace }}/repo/teslamate
           jq '.version="${{ steps.semver.outputs.semver }}"' < ${{ github.workspace }}/teslamate/config.json > ${{ github.workspace }}/repo/teslamate/config.json
           echo "$(curl --silent --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -r .body)" > ${{ github.workspace }}/repo/teslamate/CHANGELOG.md


### PR DESCRIPTION
Improve the renovate configuration so all the relevant places are updated with each new GitHub release of TeslaMate.

Also update the releaser to pull in the TeslaMate release notes into our release notes so peeps can see the TeslaMate changes, if any, directly in the changelog on Home Assistant.