### PR TITLE
Update Renovate configuration and fix inclusion of TeslaMate release notes in add-on changelog

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,16 +8,13 @@
   "prBodyTemplate": "{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}",
   "semanticCommits": "disabled",
   "commitMessageTopic": "{{#if (containsString depName 'teslamate')}}TeslaMate{{else}}{{depName}}{{/if}}",
-  "enabledManagers": ["custom.regex", "github-actions"],
+  "enabledManagers": ["custom.regex", "github-actions", "dockerfile"],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^Dockerfile$", "^build.json$"],
-      "matchStringsStrategy": "any",
+      "fileMatch": "^build.json$",
       "matchStrings": [
         "\"teslamate_version\": \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
-        "FROM=teslamate/(grafana|teslamate):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?teslamate/teslamate:(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "teslamate-org/teslamate"

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -32,6 +32,17 @@ jobs:
         with:
           semver-input: ${{ env.latest_release }}
           increment: ${{ github.event.inputs.semverIncrement }}
+      - name: Get TeslaMate release notes
+        run: |
+          touch CHANGELOG.txt
+          gh pr list --repo lildude/ha-addon-teslamate --state=merged --search="Update TeslaMate" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
+          if [ -s changelog.tmp ]; then
+            echo "## TeslaMate Release Notes" > CHANGELOG.txt
+            cat changelog.tmp >> CHANGELOG.txt
+            echo "---" >> CHANGELOG.txt
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create tag
         run: |
           git config --global user.email "actions.no-reply@github.com"
@@ -39,19 +50,11 @@ jobs:
           git tag -a v${{ steps.semver.outputs.semver }} -m 'Release automation'
           git push --tags
         working-directory: ${{ github.workspace }}/teslamate
-      - name: Get TeslaMate release notes
-        run: |
-          gh pr list --repo lildude/ha-addon-teslamate --state=merged --search="Update TeslaMate" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
-          if [ -s changelog.tmp ]; then
-            echo "## TeslaMate Release Notes" > CHANGELOG.txt
-            cat changelog.tmp >> CHANGELOG.txt
-            echo "---" >> CHANGELOG.txt
-          fi
-          rm -f CHANGELOG.txt
       - name: Create release
         uses: softprops/action-gh-release@v2.0.5
         with:
           tag_name: v${{ steps.semver.outputs.semver }}
+          body_path: CHANGELOG.txt
           generate_release_notes: true
           draft: false
           prerelease: false


### PR DESCRIPTION
I discovered a few issues with the Renovate and inclusion of TeslaMate release notes in add-on changelog introduced in earlier PR thanks to using the same code in another add-on.

This PR pulls in those changes.