### PR TITLE
Fix database check and creation

### DIFF
--- a/services/nginx/finish
+++ b/services/nginx/finish
@@ -2,8 +2,13 @@
 # -*- bash -*-
 # shellcheck shell=bash
 if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
-  bashio::log.warning "Nginx crashed, halting add-on"
+  case "${1}" in
+    1)
+      bashio::log.error "Nginx encountered an error, halting add-on"
+      ;;
+    *)
+      bashio::log.error "Nginx crashed, halting add-on"
+      ;;
+  esac
   /run/s6/basedir/bin/halt
 fi
-
-bashio::log.info "Nginx stopped, restarting..."

--- a/services/teslamate/finish
+++ b/services/teslamate/finish
@@ -2,8 +2,14 @@
 # -*- bash -*-
 # shellcheck shell=bash
 if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
-  bashio::log.warning "TeslaMate crashed, halting add-on"
+  case "${1}" in
+    1)
+      bashio::log.error "TeslaMate encountered an error, halting add-on"
+      ;;
+    *)
+      bashio::log.error "TeslaMate crashed, halting add-on"
+      ;;
+  esac
   /run/s6/basedir/bin/halt
 fi
 
-bashio::log.info "TeslaMate stopped, restarting..."

--- a/services/teslamate/run
+++ b/services/teslamate/run
@@ -51,23 +51,20 @@ fi
 
 # Create the PostgreSQL database if it doesn't exist
 if pg_isready -h "$DATABASE_HOST" -p "$DATABASE_PORT" > /dev/null 2>&1; then
-  bashio::log.info "Creating database $DATABASE_NAME on $DATABASE_HOST"
+  bashio::log.info "Creating database '$DATABASE_NAME' on $DATABASE_HOST"
 
-  res=$(PGPASSWORD="$DATABASE_PASS" psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USER" postgres -c "CREATE DATABASE $DATABASE_NAME" 2>&1) || true
-  case "$res" in
-    "CREATE DATABASE")
+  if [[ -n $(PGPASSWORD="$DATABASE_PASS" psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USER" postgres -Atqc "\list $DATABASE_NAME") ]]; then
+    bashio::log.info "Database $DATABASE_NAME already exists"
+  else
+    if PGPASSWORD="$DATABASE_PASS" psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USER" postgres -qc "CREATE DATABASE \"$DATABASE_NAME\""; then
       bashio::log.info "Database $DATABASE_NAME created"
-      ;;
-    *"already exists"*)
-      bashio::log.info "Database $DATABASE_NAME already exists"
-      ;;
-    *)
-      bashio::log.error "Failed to create database $DATABASE_NAME: $res"
+    else
+      bashio::log.error "Failed to create database $DATABASE_NAME"
       exit 1
-      ;;
-  esac
+    fi
+  fi
 else
-  bashio::log.error "PostgreSQL is not ready"
+  bashio::log.error "PostgreSQL at '$DATABASE_HOST' is not ready or unreachable"
   exit 1
 fi
 


### PR DESCRIPTION
As pointed out in https://github.com/lildude/ha-addon-teslamate/issues/15, the addon can fail to start on some occassions. On closer examination, it's due to two schoolboy errors in the check for the DB and create it if it doesn't exist:

1. It assumes the response will be in English
2. It doesn't quote the DB name when creating the DB hence the syntax error when using DB names with a hyphen.

It also doesn't provide an accurate exit message when we encounter a problem.

This PR addresses that.

Fixes https://github.com/lildude/ha-addon-teslamate/issues/15