### PR TITLE
Add optional env vars config option

### DIFF
--- a/.github/workflows/publisher.yaml
+++ b/.github/workflows/publisher.yaml
@@ -42,7 +42,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish
-        uses: home-assistant/builder@master
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             --${{ matrix.arch }} \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Build add-on
-        uses: home-assistant/builder@master
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             --test \

--- a/DOCS.md
+++ b/DOCS.md
@@ -115,6 +115,15 @@ Once you have Grafana up and running, you'll need to configure a data source to 
 
 - `import_dir`: (Optional) The path to the directory where TeslaMate should look for the TeslaMate export CSV file. Default: `/share/teslamate`.
 
+- `env_vars`: (Optional) Set additional environment variables for TeslaMate which aren't currently exposed by the configuration options in this add-on.
+
+  Each entry is made up of a name and value:
+
+  - `name`: The case-sensitive environment variable name.
+  - `value`: The value to be set in the environment variable.
+
+  Note: These will also overwrite any environment variable set using the configuration options above.
+
 ## Data Import from TeslaFi
 
 It is now possible to import CSV data from TeslaFi, refer to the [official docs][teslafi-import].

--- a/config.json
+++ b/config.json
@@ -36,7 +36,8 @@
         "timezone": "Europe/London",
         "import_dir": "/share/teslamate",
         "default_geofence": "",
-        "encryption_key": ""
+        "encryption_key": "",
+        "env_vars": []
     },
     "schema": {
         "database_user": "str",
@@ -61,7 +62,11 @@
         "timezone": "str",
         "import_dir": "str",
         "default_geofence": "str?",
-        "encryption_key": "password?"
+        "encryption_key": "password?",
+        "env_vars": [{
+            "name": "str?",
+            "value": "str?"
+        }]
     },
     "map": [
         "share:rw"

--- a/services/teslamate/run
+++ b/services/teslamate/run
@@ -44,6 +44,14 @@ export DATABASE_HOST DATABASE_NAME DATABASE_PASS DATABASE_PORT DATABASE_USER \
   DISABLE_MQTT MQTT_HOST MQTT_NAMESPACE MQTT_PASSWORD MQTT_TLS_ACCEPT_INVALID_CERTS \
   MQTT_TLS MQTT_USERNAME IMPORT_DIR PORT TZ DEFAULT_GEOFENCE ENCRYPTION_KEY URL_PATH
 
+# These are optional and applied last so we can override those set above if needed.
+for env_var in $(bashio::config 'env_vars|keys'); do
+    name=$(bashio::config "env_vars[${env_var}].name")
+    value=$(bashio::config "env_vars[${env_var}].value")
+    bashio::log.debug "Setting Env Variable ${name} to ${value}"
+    export "${name}=${value}"
+done
+
 # Import dashboards
 if bashio::config.true 'grafana_import_dashboards'; then
     /dashboards.sh restore

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -67,3 +67,6 @@ configuration:
   import_dir:
     name: TeslaFi Import Directory
     description: The directory which holds the TeslaFi export you would like to import into TeslaMate.
+  env_vars:
+    name: Environment Variables
+    description: Set additional environment variables for TeslaMate which aren't currently exposed by the configuration options in this add-on.


### PR DESCRIPTION
Almost everything in TeslaMate is configured via env vars and whilst this addon does a good job of exposing most of them as config options, there are some which it doesn't and may not. Having this new option allows advanced users to take advantage of these env vars within this addon.

My motivation is I want to test switching to using the Fleet API ([TeslaMate docs](https://docs.teslamate.org/docs/guides/api)) via the [Tesla HTTP Proxy addon](https://github.com/llamafilm/tesla-http-proxy-addon/tree/main/tesla_http_proxy) already running on my HA instance. Once I've got this working, I'll probably add it as an easy config option to this add-on.

This PR also switches to using a specific builder version as the current builder on master is [borked](https://github.com/home-assistant/builder/issues/212).