### PR TITLE
Make startup scripts robust

### DIFF
--- a/services/nginx/run
+++ b/services/nginx/run
@@ -1,6 +1,8 @@
 #!/command/with-contenv bashio
 # -*- bash -*-
 # shellcheck shell=bash
+
+bashio::log.info "Starting NGINX..."
 if [ -f /run/nginx ]; then
   rm -f /run/nginx
 fi

--- a/services/nginx/run
+++ b/services/nginx/run
@@ -1,5 +1,9 @@
 #!/command/with-contenv bashio
 # -*- bash -*-
 # shellcheck shell=bash
-mkdir /run/nginx
+if [ -f /run/nginx ]; then
+  rm -f /run/nginx
+fi
+mkdir -p /run/nginx
+
 exec nginx -g 'daemon off;error_log /proc/1/fd/1 error;'

--- a/services/teslamate/run
+++ b/services/teslamate/run
@@ -54,7 +54,7 @@ done
 
 # Import dashboards
 if bashio::config.true 'grafana_import_dashboards'; then
-    /dashboards.sh restore
+    /dashboards.sh restore || bashio::log.error "Failed to import dashboards"
 fi
 
 # Create the PostgreSQL database if it doesn't exist

--- a/services/teslamate/run
+++ b/services/teslamate/run
@@ -78,7 +78,7 @@ fi
 
 ulimit -n 1048576
 
-bashio::log.info "Starting TeslaMate"
+bashio::log.info "Starting TeslaMate..."
 
 cd /opt/app
 exec $(/usr/bin/env sh) /entrypoint.sh bin/teslamate start


### PR DESCRIPTION
A couple of issues recently have highlighted a few weaknesses in the startup scripts for Nginx and TeslaMate. This PR makes those more robust.

- Nginx will now remove `/run/nginx` if it's a file and it exists before creating the directory, which it'll now do with `mkdir -p`.

- TeslaMate will no longer fail to start if there is a problem with loading the Grafana dashboards.

- The dashboards script will now provide more information in the event of an error.

Closes https://github.com/lildude/ha-addon-teslamate/issues/32
Closes https://github.com/lildude/ha-addon-teslamate/issues/36