### PR TITLE
Only include Teslamate release notes if updated since last release

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -35,12 +35,13 @@ jobs:
       - name: Get TeslaMate release notes
         run: |
           touch CHANGELOG.txt
-          gh pr list --repo lildude/ha-addon-teslamate --state=merged --search="Update TeslaMate" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
+          last_release_date=$(gh release list --repo lildude/ha-addon-teslamate --limit=1 --json=publishedAt)
+          gh pr list --repo lildude/ha-addon-teslamate --state=merged --search="Update TeslaMate in:title closed:>$last_release_date" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
           if [ -s changelog.tmp ]; then
             echo "## TeslaMate Release Notes" > CHANGELOG.txt
             cat changelog.tmp >> CHANGELOG.txt
-            echo -e "---\n\n## Add-on Release Notes\n\n" >> CHANGELOG.txt
           fi
+          echo -e "---\n\n## Add-on Release Notes\n\n" >> CHANGELOG.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create tag


### PR DESCRIPTION
I noticed the last few patch releases have pulled in the full TeslaMate release notes. We don't need these and should only include them if TeslaMate was updated.

This PR fixes the logic I was using before so we only get the notes when I pull in an update of TeslaMate