### PR TITLE
Fix release note gathering

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get TeslaMate release notes
         run: |
           touch CHANGELOG.txt
-          last_release_date=$(gh release list --repo lildude/ha-addon-teslamate --limit=1 --json=publishedAt)
+          last_release_date=$(gh release list --repo lildude/ha-addon-teslamate --limit=1 --json=publishedAt | jq -r '.[].publishedAt')
           gh pr list --repo lildude/ha-addon-teslamate --state=merged --search="Update TeslaMate in:title closed:>$last_release_date" --limit=1 --json=body --jq '.[].body' | sed -n "/<\/summary>/,/<\/details>/p" | sed '1d;$d' > changelog.tmp
           if [ -s changelog.tmp ]; then
             echo "## TeslaMate Release Notes" > CHANGELOG.txt


### PR DESCRIPTION
I forgot to parse the JSON when obtaining the last publish date which means we probably don't get the results we need.