### PR TITLE
Document and enforce the Grafana datasource name should be `TeslaMate`

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -105,6 +105,8 @@ _Note_ that the security admin password and usernames can only be set on the fir
 
 Once you have Grafana up and running, you'll need to configure a data source to read data from the PostgreSQL database:
 
+‼️ **Note**: The name must be `TeslaMate` as all the dashboards expect the datasource to use this name.
+
 ![Grafana Postgres data source][grafana-datasource]
 
 #### Other Options

--- a/rootfs/dashboards.sh
+++ b/rootfs/dashboards.sh
@@ -54,6 +54,24 @@ backup() {
 
 
 restore() {
+  bashio::log.info "Checking for Grafana datasource: TeslaMate"
+  datasources=$(curl --silent --show-error \
+    --user "$LOGIN" -H "Content-Type: application/json" \
+    "$URL/api/datasources")
+
+  if [[ $datasources == *"statusCode"* ]]; then
+    bashio::log.error "Error getting Grafana datasources: $(echo "$datasources" | jq -r .message)"
+    bashio::log.debug "$datasources"
+    exit 1
+  fi
+
+  DS=$(echo "$datasources" | jq ".[] | select(.name==\"TeslaMate\")")
+
+  if [[ -z "$DS" ]]; then
+    bashio::log.error "'TeslaMate' datasource not found. Please create or rename your datasource. It must be named 'TeslaMate'."
+    exit 1
+  fi
+
   bashio::log.info "Checking for Grafana folder: $FOLDER_NAME"
   folders=$(curl --silent --show-error \
     --user "$LOGIN" -H "Content-Type: application/json" \


### PR DESCRIPTION
The troubles in https://github.com/lildude/ha-addon-teslamate/issues/63 turned out to be due to the Grafana datasource not being named `TeslaMate`. On closer examination, this appears to be a [documented hard requirement](https://docs.teslamate.org/docs/installation/debian#import-grafana-dashboards) as the underlying dashboards expect the datasource name to be `TeslaMate`.

This PR updates the docs to make this clear and also adds a check to ensure the datasource is named `TeslaMate` in the `dashboards.sh` script. If not, an error is raised.