### PR TITLE
Update config to enable hassio_api access and improve TeslaMate settings message

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
         "aarch64",
         "amd64"
     ],
+    "hassio_api": true,
     "ingress": true,
     "init": false,
     "panel_icon": "mdi:car-connected",

--- a/rootfs/etc/s6-overlay/s6-rc.d/teslamate/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/teslamate/run
@@ -76,9 +76,12 @@ else
   exit 1
 fi
 
-if [[ -z $(PGPASSWORD="$DATABASE_PASS" psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USER" "$DATABASE_NAME" -Atqc "SELECT 1 FROM settings WHERE base_url LIKE '%api/hassio_ingress%'" 2&> /dev/null ) ]]; then
+if [[ -z $(PGPASSWORD="$DATABASE_PASS" psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USER" "$DATABASE_NAME" -Atqc "SELECT 1 FROM settings WHERE base_url LIKE '%api/hassio_ingress%'" 2> /dev/null ) ]]; then
   teslamate_ingress=$(bashio::addon.ingress_entry)
   grafana_ingress=$(bashio::addon.ingress_entry $(bashio::supervisor.addons | grep grafana))
+  if [[ "$teslamate_ingress" == "$grafana_ingress" ]]; then
+    grafana_ingress="** Grafana addon not found. Ensure the addon is installed and running. **"
+  fi
 
   bashio::log.info "Configure TeslaMate settings by adding these values
                  to the URL you use to access your Home Assistant instance:


### PR DESCRIPTION
After installing the latest version of this addon I noticed the following error:

```
[12:00:34] INFO: Starting NGINX...
s6-rc: info: service legacy-services successfully started
[12:00:35] INFO: Checking for database 'teslamate' on db21ed7f-postgres
[12:00:35] INFO: Database teslamate already exists
[12:00:35] ERROR: Unable to access the API, forbidden
[12:00:35] INFO: Configure TeslaMate settings by adding these values
                 to the URL you use to access your Home Assistant instance:
  => Web App: /api/hassio_ingress/euHjiRihMzTGK1oz_WiBqfuVI7idDHhhf-xM62fIQBk
  => Dashboards: /api/hassio_ingress/euHjiRihMzTGK1oz_WiBqfuVI7idDHhhf-xM62fIQBk
  
[12:00:35] INFO: Starting TeslaMate...
```

Looks like I missed updating the config when I added that. This PR fixes that which in turn will also ensure we don't end up with duplicate URLs.

It also fixes a typo I made in the previous PR where I redirect STDOUT too thus causing this message to always appear, even if you've updated the settings, and improved things in the event the Grafana addon can't be found.

