### PR TITLE
Only set file limit to a max of 524288

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/teslamate/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/teslamate/run
@@ -113,7 +113,11 @@ if [[ -z $(PGPASSWORD="$DATABASE_PASS" psql -h "$DATABASE_HOST" -p "$DATABASE_PO
   bashio::log.notice "=> Dashboards: $grafana_ingress"
   bashio::log.notice ""
 fi
-ulimit -n 1048576
+
+# Set max open file limit to avoid memory allocation issues
+if [ "$(ulimit -Hn)" -gt 524288 ]; then
+    ulimit -n 524288
+fi
 
 bashio::log.info "Starting TeslaMate..."
 


### PR DESCRIPTION
A new RC build of Home Assistant OS includes a change in containerd that [removes a previously unlimited file limit setting](https://github.com/containerd/containerd/commit/3ca39ef01608fdd44245c0173bf071682b3bfe3c). The new max is 524288 so we shouldn't be attempting to set the limit higher than this.

Closes https://github.com/lildude/ha-addon-teslamate/issues/92